### PR TITLE
Fix for the chrome javascript interpreter issue

### DIFF
--- a/assets/www/js/CDVInterface.js
+++ b/assets/www/js/CDVInterface.js
@@ -6,30 +6,32 @@
 * Created by Christoffer Rosen
 * 12/23/2013
 **/
-
-CDVInterface: function ( callbackSuccess, callbackError ){
-	
-	/**
-	* Expects the following arguments; dcs url, start time, end time,
-	* tour id, and rider id. It will automatically start tracking the user
-	* at the start time and stop tracking at the tour end time.
-	**/
-	start: function( callbackSuccess, callbackError, arguments ){
-		cordova.exec(callbackSuccess, callbackError, "CDVInterface", "start", arguments)
-	},
-	
-	/**
-	* Pauses tracking the rider, expects no arguments
-	*/
-	pauseTracking: function( callbackSuccess, callbackError, arguments ){
-		cordova.exec(callbackSuccess, callbackError, "CDVInterface", "pauseTracking", arguments)
-	},
-	
-	/**
-	* Resumes tracking the rider if paused AND the tour is still ongoing.
-	* Expects no arguments.
-	*/
-	resumeTracking: function( callbackSuccess, callbackError, arguments ){
-		cordova.exec(callbackSuccess, callbackError, "CDVInterface", "resumeTracking", arguments)
+return {
+	CDVInterface: function ( callbackSuccess, callbackError ){
+		return {
+			/**
+			* Expects the following arguments; dcs url, start time, end time,
+			* tour id, and rider id. It will automatically start tracking the user
+			* at the start time and stop tracking at the tour end time.
+			**/
+			start: function( callbackSuccess, callbackError, arguments ){
+				cordova.exec(callbackSuccess, callbackError, "CDVInterface", "start", arguments)
+			},
+			
+			/**
+			* Pauses tracking the rider, expects no arguments
+			*/
+			pauseTracking: function( callbackSuccess, callbackError, arguments ){
+				cordova.exec(callbackSuccess, callbackError, "CDVInterface", "pauseTracking", arguments)
+			},
+			
+			/**
+			* Resumes tracking the rider if paused AND the tour is still ongoing.
+			* Expects no arguments.
+			*/
+			resumeTracking: function( callbackSuccess, callbackError, arguments ){
+				cordova.exec(callbackSuccess, callbackError, "CDVInterface", "resumeTracking", arguments)
+			}
+		};
 	}
 };


### PR DESCRIPTION
Chrome was not accepting "a: function(){ b: function(){} }" as valid syntax. This redefines the functions as part of objects being returned so that "a().b()" is still valid
